### PR TITLE
Improve MariaDB installation and docker-compose healthcheck

### DIFF
--- a/mariadb/docker-compose.yml
+++ b/mariadb/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - MIFOS_PRELOAD_CLIENTS=true
       - MIFOS_DEFAULT_CHAR_DELIMITER=,
     ports:
-      - 80:80
+      - ${WEB_APP_PORT:-80}:${WEB_APP_PORT:-80}
   # Database service
   fineractmysql:
     image: mariadb:11.8.2
@@ -33,7 +33,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", "--password=${MYSQL_ROOT_PASSWORD}" ]
+      test: ["CMD", "mariadb-admin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]
       timeout: 10s
       retries: 10
   # Backend service
@@ -46,7 +46,7 @@ services:
       timeout: 10s
       retries: 10
     ports:
-      - ${FINERACT_PORT:-8080}:8080
+      - ${FINERACT_PORT:-8080}:${FINERACT_PORT:-8080}
     depends_on:
       fineractmysql:
         condition: service_healthy
@@ -88,5 +88,5 @@ services:
       - FINERACT_DEFAULT_TENANTDB_NAME=fineract_default
       - FINERACT_DEFAULT_TENANTDB_DESCRIPTION=Default Demo Tenant
       - FINERACT_SERVER_SSL_ENABLED=false
-      - FINERACT_SERVER_PORT=8080
+      - FINERACT_SERVER_PORT=${FINERACT_PORT:-8080}
       - FINERACT_LOGGING_LEVEL=INFO

--- a/mariadb/fineract-db/docker/mariadb.env
+++ b/mariadb/fineract-db/docker/mariadb.env
@@ -1,5 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # MariaDB Environment Configuration
 TAG=latest
 SERVER_URL=http://localhost:8080
 FINERACT_PORT=8080
-MYSQL_ROOT_PASSWORD=password 
+WEB_APP_URL=http://localhost:80
+WEB_APP_PORT=80
+MARIADB_USER=root
+MYSQL_ROOT_PASSWORD=your_secure_password_here
+FINERACT_DB_USER=root
+FINERACT_DB_PASS=your_secure_password_here
+FINERACT_TENANTS_DB_NAME=fineract_tenants
+FINERACT_TENANT_DEFAULT_DB_NAME=fineract_default

--- a/postgresql/docker-compose.yml
+++ b/postgresql/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     image: openmf/web-app:dev
     restart: always
     environment:
-      - FINERACT_API_URLS=${SERVER_URL}
-      - FINERACT_API_URL=${SERVER_URL}
+      - FINERACT_API_URLS=${SERVER_URL:-http://localhost:8080}
+      - FINERACT_API_URL=${SERVER_URL:-http://localhost:8080}
       - FINERACT_API_PROVIDER=/fineract-provider/api
       - FINERACT_API_VERSION=/v1
       - FINERACT_PLATFORM_TENANT_IDENTIFIER=default
@@ -15,7 +15,7 @@ services:
       - MIFOS_PRELOAD_CLIENTS=true
       - MIFOS_DEFAULT_CHAR_DELIMITER=,
     ports:
-      - 80:80
+      - ${WEB_APP_PORT:-80}:${WEB_APP_PORT:-80}
   # Database service
   postgresql:
     image: postgres:17.5
@@ -84,5 +84,5 @@ services:
       - FINERACT_DEFAULT_TENANTDB_NAME=fineract_default
       - FINERACT_DEFAULT_TENANTDB_DESCRIPTION=Default Demo Tenant
       - FINERACT_SERVER_SSL_ENABLED=false
-      - FINERACT_SERVER_PORT=${FINERACT_PORT}
+      - FINERACT_SERVER_PORT=${FINERACT_PORT:-8080}
       - FINERACT_LOGGING_LEVEL=INFO

--- a/postgresql/fineract-db/docker/postgresql.env
+++ b/postgresql/fineract-db/docker/postgresql.env
@@ -20,9 +20,11 @@
 TAG=latest
 SERVER_URL=http://localhost:8080
 FINERACT_PORT=8080
+WEB_APP_URL=http://localhost:80
+WEB_APP_PORT=80
 POSTGRES_USER=root
 PG_PASSWORD=your_secure_password_here
-POSTGRES_PASSWORD=your_secure_password_here
+POSTGRES_PASSWORD=superuser_secure_password_here
 FINERACT_DB_USER=postgres
 FINERACT_DB_PASS=your_secure_password_here
 FINERACT_TENANTS_DB_NAME=fineract_tenants


### PR DESCRIPTION
- Add necessary commands for Mac compatibility
- Fix support for MariaDB to assist the installation process
- Fix sed command error in install.sh script
- Add environment variables to configure Web App port and URL
- Correct docker-compose healthcheck to use mariadb-admin instead of mysql for mariadb:11.8.2 image
  - test: ["CMD", "mariadb-admin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]