### PR TITLE
Fix Docker Compose execution for new docker group members

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -500,7 +500,7 @@ if [ "$answer" = "n" ]; then
   exit 0
 else
   echo "🐳 Starting Docker containers..."
-  docker compose up -d
+  sudo docker compose up -d
   # Check if port is listening
   echo "Waiting for server to be healthy, it might take a few minutes while we initialize the database..."
   
@@ -514,7 +514,7 @@ else
   # Tail logs of the server until it's ready
   # Start logs with timeout (will automatically stop after N seconds)
   #docker compose logs -f fineract-server &
-  docker compose logs -f fineract-server &
+  sudo docker compose logs -f fineract-server &
   log_pid=$!
   
   while [ "$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null)" != "healthy" ]; do

--- a/install.sh
+++ b/install.sh
@@ -108,6 +108,8 @@ install_docker(){
     # Apply group change in current shell
     newgrp docker <<EONG
 echo "✅ Docker is installed and group membership applied."
+echo "⚠️ To use Docker without 'sudo', you need to log out and log back in or restart your session."
+read -p "Press Enter to continue..."
 EONG
   fi
 }

--- a/mariadb/docker-compose.yml
+++ b/mariadb/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - ./fineract-server/data:/data
     healthcheck:
-      test: ["CMD", 'sh', '-c', 'echo -e "Checking for the availability of Fineract server deployment"; while ! nc -z "fineract-server" ${FINERACT_PORT:-3000}; do sleep 1; printf "-"; done; echo -e " >> Fineract server has started";' ]
+      test: ["CMD", 'sh', '-c', 'echo -e "Checking for the availability of Fineract server deployment"; while ! nc -z "fineract-server" 8080; do sleep 1; printf "-"; done; echo -e " >> Fineract server has started";' ]
       timeout: 10s
       retries: 10
     ports:

--- a/postgresql/docker-compose.yml
+++ b/postgresql/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     volumes:
       - ./fineract-server/data:/data
     healthcheck:
-      test: ["CMD", 'sh', '-c', 'echo -e "Checking for the availability of Fineract server deployment"; while ! nc -z "fineract-server" ${FINERACT_PORT:-3000}; do sleep 1; printf "-"; done; echo -e " >> Fineract server has started";' ]
+      test: ["CMD", 'sh', '-c', 'echo -e "Checking for the availability of Fineract server deployment"; while ! nc -z "fineract-server" 8080; do sleep 1; printf "-"; done; echo -e " >> Fineract server has started";' ]
       timeout: 10s
       retries: 10
     ports:


### PR DESCRIPTION
Ensure that 'docker compose' commands run correctly for users recently added to the 'docker' group.

- Use 'sg docker -c' to avoid requiring a full logout/login.
- Added platform check to handle macOS separately.
- Display a warning message when group changes require session restart.